### PR TITLE
Add ZPlatform.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Join us in building a stronger ecosystem for AI tools by exploring, contributing
 | What the AI | [What the AI](https://whattheai.tech/) | [Submit](https://whattheai.tech/submit-a-tool/) | 28 | 50000 | 
 | Whatsthebigdata | [Whatsthebigdata](https://whatsthebigdata.com/) | [Submit](https://whatsthebigdata.com/submit-new-ai-tool ) | 60 | 2700000 | 
 | Woi AI | [Woi AI](https://woy.ai/) | [Submit](https://woy.ai/submit) | 64 | 43400 | 
+| ZPlatform.ai | [ZPlatform.ai](https://zplatform.ai/) | [Submit](https://zplatform.ai/) | 51 | - | 
 
 
 ---


### PR DESCRIPTION
Adds **ZPlatform.ai** to the AI Directories List.

- **Name:** ZPlatform.ai
- **Link:** https://zplatform.ai/
- **Description:** A directory of AI tools and software/SaaS deals (including lifetime deals), organized by category. Each tool is tested hands-on with a Buy / Wait / Skip verdict.
- **Domain Rating:** 51 (Ahrefs)

The entry follows the existing table format and is placed in alphabetical order at the end of the list (after Woi AI). Monthly Visits left as `-` consistent with other rows where the value is unavailable.